### PR TITLE
Enhance GitHub Action: Add 'dockerfile_path' input and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This action's job is to build a Docker image, and then push it to GCP's Artifact
 
 - This is the GCP Credentials JSON. It is recommended to store the value feeding this input in GitHub secrets.
 
+##### dockerfile_path
+
+- This is the path to the Dockerfile.
+
 ##### docker_target
 
 - This is the specified Docker target for Docker build command.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "Google Cloud Service Account JSON, it is recommended to feed this with a GitHub secret value."
     required: true
 
+  dockerfile_path:
+    description: "Path to the Dockerfile."
+    required: true
+    default: "Dockerfile"
+
   docker_target:
     description: "Docker target stage."
     required: true
@@ -34,7 +39,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        file: Dockerfile
+        file: ${{ inputs.dockerfile_path }}
         target: ${{ inputs.docker_target }}
         push: true
         build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
- Introduced a new input parameter 'dockerfile_path' in action.yml to specify the path to the Dockerfile, with a default value of 'Dockerfile'.
- Updated README.md to document the new 'dockerfile_path' input, providing clarity on its purpose.